### PR TITLE
Team/role auth fixed using bitbucket workspaces endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Supported roles are `admin`, `contributor` and `member`
 
 Examples
 ```
-team1::admin
-team2::contributor
+team1::owner
+team2::collaborator
 team3::member
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -71,8 +71,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.8</source>
+					<target>1.8</target>
 					<debug>true</debug>
 				</configuration>
 			</plugin>

--- a/src/main/java/org/jenkinsci/plugins/api/BitbucketApiService.java
+++ b/src/main/java/org/jenkinsci/plugins/api/BitbucketApiService.java
@@ -60,8 +60,8 @@ public class BitbucketApiService {
 
         bitbucketUser.addAuthority("authenticated");
 
-        findAndAddUserTeamAccess(accessToken, bitbucketUser, "admin");
-        findAndAddUserTeamAccess(accessToken, bitbucketUser, "contributor");
+        findAndAddUserTeamAccess(accessToken, bitbucketUser, "owner");
+        findAndAddUserTeamAccess(accessToken, bitbucketUser, "collaborator");
         findAndAddUserTeamAccess(accessToken, bitbucketUser, "member");
 
         return bitbucketUser;
@@ -93,7 +93,7 @@ public class BitbucketApiService {
     private void findAndAddUserTeamAccess(Token accessToken, BitbucketUser bitbucketUser, String role) {
         // require "Team membership Read" permission
         Gson gson = new Gson();
-        String url = API2_ENDPOINT + "teams/?role=" + role;
+        String url = API2_ENDPOINT + "workspaces/?role=" + role;
         try {
             do {
                 OAuthRequest request1 = new OAuthRequest(Verb.GET, url);

--- a/src/main/java/org/jenkinsci/plugins/api/BitbucketTeams.java
+++ b/src/main/java/org/jenkinsci/plugins/api/BitbucketTeams.java
@@ -4,13 +4,13 @@ import com.google.gson.annotations.SerializedName;
 
 public class BitbucketTeams
 {
-    @SerializedName("username")
+    @SerializedName("slug")
     String username;
 
     @SerializedName("type")
     String type;
 
-    @SerializedName("display_name")
+    @SerializedName("name")
     String displayName;
 
     public String getUsername()


### PR DESCRIPTION
The bitbucket api teams endpoint has been removed from Bitbucket API and therefore, the jenkins authentication using this plugin based on team/roles permissions doesn't work as expected.

After bitbucket login, you will get Access Denied msg with the following error:

<user> is missing the Overall/Read permission"

This is happening because the teams endpoint is removed and we must use the workspaces endpoint instead.
More information here: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-teams/#api-teams-get

This PR contains small changes to allow the plugin use the right endpoint and parse the response according the api especification.